### PR TITLE
Avoid an edge explosion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@ impl<'a> MergeState<'a> {
                 &OldItemInfo::Unused(_) => panic!("should only encounter used predecessors"),
                 &OldItemInfo::BeingProcessed => panic!("somebody forgot to clean up"),
                 &OldItemInfo::Discarded(ref discarded_item_direct_predecessors) => {
-                    result.extend(discarded_item_direct_predecessors)
+                    result.extend(&discarded_item_direct_predecessors[0..discarded_item_direct_predecessors.len().min(1)])
                 }
                 &OldItemInfo::AddedToMergedList(index_in_merged_dag) => {
                     result.push(index_in_merged_dag)


### PR DESCRIPTION
We only choose one edge from the deleted item instead of all of them.

It seems believable that we don't need all of the edges from a deleted item to be propagated.
I'm not sure this is completely correct, but it hasn't failed fuzzing yet (with my change to make deletions work properly)

This means either the fuzzing doesn't work well or this does.